### PR TITLE
Makefile: Specific lua version to 5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BIN = interpreter \
 
 CROSS_COMPILE = arm-linux-gnueabihf-
 QEMU_ARM = qemu-arm -L /usr/arm-linux-gnueabihf
-LUA = lua
+LUA = lua5.2
 
 all: $(BIN)
 


### PR DESCRIPTION
Testing on Lua 5.3.2, when compiling, it will throw an exception
"jit-x86.dasc:4: error: cannot load module:
 dynasm/dasm_x86.lua:31: module 'bit' not found"

According to Lua Bitop website, Bitop only support Lua 5.1/5.2.
(http://bitop.luajit.org/)

"Lua BitOp is a C extension module for Lua 5.1/5.2
which adds bitwise operations on numbers."

Also, in embedded2015/rubi Makefile, it has specific
Lua version on 5.2, too.